### PR TITLE
Fix database_url key in config template

### DIFF
--- a/config/local.example.toml
+++ b/config/local.example.toml
@@ -1,8 +1,8 @@
 # Example MySQL DSN:
-database_url = "mysql://sample_user:sample_password@localhost/syncstorage_rs"
+syncstorage.database_url = "mysql://sample_user:sample_password@localhost/syncstorage_rs"
 
 # Example Spanner DSN:
-# database_url="spanner://projects/SAMPLE_GCP_PROJECT/instances/SAMPLE_SPANNER_INSTANCE/databases/SAMPLE_SPANNER_DB"
+# syncstorage.database_url="spanner://projects/SAMPLE_GCP_PROJECT/instances/SAMPLE_SPANNER_INSTANCE/databases/SAMPLE_SPANNER_DB"
 
 "limits.max_total_records"=1666 # See issues #298/#333
 master_secret = "INSERT_SECRET_KEY_HERE"


### PR DESCRIPTION
## Description

* Regression in #1306
* `database_url` got moved into (and is now expected in) a new `syncstorage` parent

To quote the original PR description:

    Because of the naming changes in this PR, the names of environment variables and settings in local.toml will need to change. 

Yet that exact change wasn't done as part of the PR. This is particularly important as the README uses the example config as a template when setting up a new server.

## Testing
1. Use the original config as a template and your configured `database_url` won't be used at all
2. Merge the patch and test again
3. Works